### PR TITLE
Migrating from master-slave terminology

### DIFF
--- a/reaction/reaction.go
+++ b/reaction/reaction.go
@@ -169,5 +169,5 @@ func main() {
 	
 	urlCheck(&config)    //do our check
 	
-	wg.Wait()	//wait for the slave and possible master to finish
+	wg.Wait()	//wait for the subordinate and possible main to finish
 }


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.